### PR TITLE
主に遷移先・ステータス・商品個数の変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,11 @@ class ApplicationController < ActionController::Base
 
       #サインアウト後の遷移
   def after_sign_out_path_for(resource)
+    if resource == :admin
+    admin_session_path
+    else
     root_path
+    end
   end
 
   def configure_permitted_parameters

--- a/app/controllers/private/genres_controller.rb
+++ b/app/controllers/private/genres_controller.rb
@@ -1,5 +1,5 @@
 class Private::GenresController < ApplicationController
-   # before_action :authenticate_admin_user!
+   before_action :authenticate_admin!
 
   def index
     @genres = Genre.all

--- a/app/controllers/private/members_controller.rb
+++ b/app/controllers/private/members_controller.rb
@@ -1,5 +1,5 @@
 class Private::MembersController < ApplicationController
-   # before_action :authenticate_admin_user!
+   before_action :authenticate_admin!
 
 
   def index

--- a/app/controllers/private/ordered_products_controller.rb
+++ b/app/controllers/private/ordered_products_controller.rb
@@ -2,12 +2,18 @@ class Private::OrderedProductsController < ApplicationController
 
   def update
       @ordered_product = OrderedProduct.find(params[:id])
-    if @ordered_product.update(ordered_product_params)
-    flash[:notice] = "注文ステータスを更新しました"
+      @order = @ordered_product.order
+      @ordered_product.update(ordered_product_params)
+
+      if @ordered_product.production_status == "製作中"
+          @order.update(order_status: 2)
+
+      elsif @order.ordered_products.count == @order.ordered_products.where(production_status: 3).count
+          @order.update(order_status: 3)
+      end
+
+    flash[:notice] = "製作ステータスを更新しました"
     redirect_to private_order_path(@ordered_product.order)
-    else
-    render show
-    end
   end
 
   private

--- a/app/controllers/private/ordered_products_controller.rb
+++ b/app/controllers/private/ordered_products_controller.rb
@@ -1,5 +1,5 @@
 class Private::OrderedProductsController < ApplicationController
-
+   before_action :authenticate_admin!
   def update
       @ordered_product = OrderedProduct.find(params[:id])
       @order = @ordered_product.order

--- a/app/controllers/private/orders_controller.rb
+++ b/app/controllers/private/orders_controller.rb
@@ -12,12 +12,13 @@ class Private::OrdersController < ApplicationController
 
   def update
     @order = Order.find(params[:id])
-    if @order.update(order_params)
+    @order.update(order_params)
+    if @order.order_status == "入金確認"
+        @order.ordered_products.update(production_status: 1) #製作ステータスを"製作待ち"にかえる
+
+    end
       flash[:notice] = "注文ステータスを更新しました"
       redirect_to private_order_path(@order)
-    else
-      render show
-    end
   end
 
   private

--- a/app/controllers/private/orders_controller.rb
+++ b/app/controllers/private/orders_controller.rb
@@ -1,5 +1,5 @@
 class Private::OrdersController < ApplicationController
-   # before_action :authenticate_admin_user!
+   before_action :authenticate_admin!
 
   def index
     @orders = Order.all.page(params[:page]).per(10)

--- a/app/controllers/private/products_controller.rb
+++ b/app/controllers/private/products_controller.rb
@@ -1,5 +1,5 @@
 class Private::ProductsController < ApplicationController
-  # before_action :authenticate_admin_user!
+   before_action :authenticate_admin!
   before_action :set_tax
 
   def index

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -1,7 +1,7 @@
 class Public::MembersController < ApplicationController
-  
+
   before_action :authenticate_member!#ログインユーザのみ実行
-  
+
   def out
     @member = current_member
     @member.update(is_deleted: true )

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,4 +1,3 @@
-<!--表示のみ-->
-  <%=form_with url:private_products_path do |f| %>
-    <%= f.text_field :search, placeholder: "Search",:size=>"20x10" %>
+<%=form_with url:private_products_path do |f| %>
+  <%= f.text_field :search, placeholder: "Search",:size=>"20x10" %>
   <% end %>

--- a/app/views/private/orders/index.html.erb
+++ b/app/views/private/orders/index.html.erb
@@ -25,7 +25,7 @@
                   <%= order.member.family_name %><%= order.member.first_name %>
                 </td>
                 <td class="p-2 border-bottom">
-                  <%= order.ordered_products.count %>
+                  <%= order.ordered_products.sum(:quantity) %>
                 </td>
                 <td class="p-2 border-bottom">
                   <%= order.order_status %>

--- a/app/views/private/orders/show.html.erb
+++ b/app/views/private/orders/show.html.erb
@@ -47,7 +47,7 @@
           </div>
             <div class="field col-10 ">
             <%= form_with model: @order, url: private_order_path, local: true, method: :patch  do |f|  %>
-              <%= f.select :order_status, ["入金待ち","入金確認","製作中","発送準備中","発送済み"], class: "" %>
+              <%= f.select :order_status,Order.order_statuses.keys,include_order_status: "入金待ち" %>
               <%= f.submit "更新", class: "btn btn-success" %>
           </div>
 
@@ -79,7 +79,7 @@
                   <td><%= (ordered_product.purchased_price)*(ordered_product.quantity) %></td>
                 <%= form_with model: ordered_product, url: private_ordered_product_path(ordered_product), local: true, method: :patch do |f|  %>
                   <td>
-                    <%= f.select :production_status,["着手不可","制作待ち","製作中","制作完了"] %>
+                    <%= f.select :production_status, OrderedProduct.production_statuses.keys,include_production_status: "着手不可" %>
                     <%= f.submit "更新", class: "btn btn-success" %>
                   </td>
                 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module NaganocakeZ
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
管理者側がログアウトした時の遷移先の変更
ステータス関係を要件定義書通りに動かせるように変更
管理者側の会員一覧画面での商品個数を変更
登録日時を日本時間になるように変更
管理者がログインしてないと行けないようにbefore_actionの追加をしました
ご確認の上マージお願いします。